### PR TITLE
Remember password

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   # Include turbolinks redirection methods
 	include Turbolinks::Redirection
 
-  protect_from_forgery with: :exception
+  protect_from_forgery prepend: true, with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,7 @@
+# Edit as needed
+#
+# source: devise-4.3.0/app/controllers/devise/passwords_controller.rb
+# default templates in app/views/devise/passwords/
+
+class PasswordsController < Devise::PasswordsController
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
 
   root to: 'visitors#index'
 
-  devise_for :users, :controllers => {sessions: 'sessions', registrations: 'registrations'} # CSRF_forgery makes this fail :3
+  devise_for :users, controllers: {
+    sessions: 'sessions', registrations: 'registrations', passwords: 'passwords'
+  } # CSRF_forgery makes this fail :3
 
   resources :users
 


### PR DESCRIPTION
* Added `prepend: true` to `protect_from_forgery` as this is not executed before callbacks in rails 5 and causes issues (https://github.com/rails/rails/commit/39794037817703575c35a75f1961b01b83791191).

* Added "empty" `PasswordsController` to override default's `Devise::PasswordsController` if needed.

* Edit view templates `views/devise/passwords/new` and `views/devise/passwords/edit` for "send recovery link" form and "change password" form, respectively.

* Edit `views/devise/mailer/reset_password_instrucctions.html.erb`as needed.

> Note:
In regards with uploads (such as user avatars), if you were to load balance a multi-host deployment, these should be stored either using a shared NFS mounted folder or S3 using Fog. We can setup the latter for you if you pass us AWS S3 credentials.